### PR TITLE
Add multi-file import support and editable text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@google/generative-ai": "^0.2.1",
         "@headlessui/react": "^1.7.18",
+        "@types/pdfjs-dist": "^2.10.377",
         "framer-motion": "^11.0.3",
         "lucide-react": "^0.344.0",
+        "pdfjs-dist": "^5.3.31",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.4"
@@ -763,6 +765,188 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.70.tgz",
+      "integrity": "sha512-nD6NGa4JbNYSZYsTnLGrqe9Kn/lCkA4ybXt8sx5ojDqZjr2i0TWAHxx/vhgfjX+i3hCdKWufxYwi7CfXqtITSA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.70",
+        "@napi-rs/canvas-darwin-arm64": "0.1.70",
+        "@napi-rs/canvas-darwin-x64": "0.1.70",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.70",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.70",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.70",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.70",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.70",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.70",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.70"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.70.tgz",
+      "integrity": "sha512-I/YOuQ0wbkVYxVaYtCgN42WKTYxNqFA0gTcTrHIGG1jfpDSyZWII/uHcjOo4nzd19io6Y4+/BqP8E5hJgf9OmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.70.tgz",
+      "integrity": "sha512-4pPGyXetHIHkw2TOJHujt3mkCP8LdDu8+CT15ld9Id39c752RcI0amDHSuMLMQfAjvusA9B5kKxazwjMGjEJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.70.tgz",
+      "integrity": "sha512-+2N6Os9LbkmDMHL+raknrUcLQhsXzc5CSXRbXws9C3pv/mjHRVszQ9dhFUUe9FjfPhCJznO6USVdwOtu7pOrzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.70.tgz",
+      "integrity": "sha512-QjscX9OaKq/990sVhSMj581xuqLgiaPVMjjYvWaCmAJRkNQ004QfoSMEm3FoTqM4DRoquP8jvuEXScVJsc1rqQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.70.tgz",
+      "integrity": "sha512-LNakMOwwqwiHIwMpnMAbFRczQMQ7TkkMyATqFCOtUJNlE6LPP/QiUj/mlFrNbUn/hctqShJ60gWEb52ZTALbVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.70.tgz",
+      "integrity": "sha512-wBTOllEYNfJCHOdZj9v8gLzZ4oY3oyPX8MSRvaxPm/s7RfEXxCyZ8OhJ5xAyicsDdbE5YBZqdmaaeP5+xKxvtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.70.tgz",
+      "integrity": "sha512-GVUUPC8TuuFqHip0rxHkUqArQnlzmlXmTEBuXAWdgCv85zTCFH8nOHk/YCF5yo0Z2eOm8nOi90aWs0leJ4OE5Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.70.tgz",
+      "integrity": "sha512-/kvUa2lZRwGNyfznSn5t1ShWJnr/m5acSlhTV3eXECafObjl0VBuA1HJw0QrilLpb4Fe0VLywkpD1NsMoVDROQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.70.tgz",
+      "integrity": "sha512-aqlv8MLpycoMKRmds7JWCfVwNf1fiZxaU7JwJs9/ExjTD8lX2KjsO7CTeAj5Cl4aEuzxUWbJPUUE2Qu9cZ1vfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.70.tgz",
+      "integrity": "sha512-Q9QU3WIpwBTVHk4cPfBjGHGU4U0llQYRXgJtFtYqqGNEOKVN4OT6PQ+ve63xwIPODMpZ0HHyj/KLGc9CWc3EtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1126,6 +1310,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
+    },
+    "node_modules/@types/pdfjs-dist": {
+      "version": "2.10.377",
+      "resolved": "https://registry.npmjs.org/@types/pdfjs-dist/-/pdfjs-dist-2.10.377.tgz",
+      "integrity": "sha512-RNBWpazVTkC5aiUIIo6d7ojlL0hJSoeQP1QCvTsVLW6qkNEpTALiI0DNGCYAGDfhbL0r17c/zNPQ15lk948UXg==",
+      "license": "MIT",
+      "dependencies": {
+        "pdfjs-dist": "*"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -2100,6 +2293,18 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.3.31",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.3.31.tgz",
+      "integrity": "sha512-EhPdIjNX0fcdwYQO+e3BAAJPXt+XI29TZWC7COhIXs/K0JHcUt1Gdz1ITpebTwVMFiLsukdUZ3u0oTO7jij+VA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.67"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@google/generative-ai": "^0.2.1",
     "@headlessui/react": "^1.7.18",
+    "@types/pdfjs-dist": "^2.10.377",
     "framer-motion": "^11.0.3",
     "lucide-react": "^0.344.0",
+    "pdfjs-dist": "^5.3.31",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.4"

--- a/src/components/FileOperations/hooks/useFileOperations.ts
+++ b/src/components/FileOperations/hooks/useFileOperations.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { readFileAsText } from '../../../utils/fileOperations';
 
 interface UseFileOperationsProps {
   content: string;
@@ -33,16 +34,21 @@ export function useFileOperations({ content, onContentChange }: UseFileOperation
       setIsLoading(true);
       const input = document.createElement('input');
       input.type = 'file';
-      input.accept = '.txt';
-      
+      input.accept = '.txt,.json,.csv,.pdf';
+
       input.onchange = async (e) => {
         const file = (e.target as HTMLInputElement).files?.[0];
         if (file) {
-          const text = await file.text();
-          onContentChange(text);
+          const text = await readFileAsText(file);
+          try {
+            const data = JSON.parse(text);
+            onContentChange(typeof data.content === 'string' ? data.content : text);
+          } catch {
+            onContentChange(text);
+          }
         }
       };
-      
+
       input.click();
     } catch (err) {
       setError('שגיאה בייבוא הקובץ');

--- a/src/components/TeleprompterEditor/hooks/useFileOperations.ts
+++ b/src/components/TeleprompterEditor/hooks/useFileOperations.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { readFileAsText } from '../../../utils/fileOperations';
 
 interface UseFileOperationsProps {
   content: string;
@@ -21,18 +22,17 @@ export const useFileOperations = ({ content, onContentChange }: UseFileOperation
   const handleImport = useCallback(() => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.txt';
-    input.onchange = (e) => {
+    input.accept = '.txt,.json,.csv,.pdf';
+    input.onchange = async (e) => {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (file) {
-        const reader = new FileReader();
-        reader.onload = (e) => {
-          const text = e.target?.result;
-          if (typeof text === 'string') {
-            onContentChange(text);
-          }
-        };
-        reader.readAsText(file);
+        const text = await readFileAsText(file);
+        try {
+          const data = JSON.parse(text);
+          onContentChange(typeof data.content === 'string' ? data.content : text);
+        } catch {
+          onContentChange(text);
+        }
       }
     };
     input.click();

--- a/src/components/TeleprompterView/TextDisplay.tsx
+++ b/src/components/TeleprompterView/TextDisplay.tsx
@@ -8,14 +8,18 @@ interface TextDisplayProps {
   speed: number;
   mirrorText: boolean;
   countdown: number;
+  editable?: boolean;
+  onChange?: (text: string) => void;
 }
 
-const TextDisplay = forwardRef<HTMLDivElement, TextDisplayProps>(({
+const TextDisplay = forwardRef<HTMLDivElement, TextDisplayProps>(({ 
   content,
   fontSize,
   isScrolling,
   mirrorText,
   countdown,
+  editable = false,
+  onChange,
 }, ref) => {
   return (
     <div className="relative flex-1">
@@ -36,6 +40,9 @@ const TextDisplay = forwardRef<HTMLDivElement, TextDisplayProps>(({
         className="h-[80vh] overflow-y-auto teleprompter-scrollbar bg-black/80
                    rounded-xl shadow-2xl p-8 text-white"
         dir="rtl"
+        contentEditable={editable}
+        suppressContentEditableWarning={true}
+        onInput={editable ? (e => onChange?.((e.target as HTMLElement).innerText)) : undefined}
       >
         {content || 'הכנס טקסט להצגה...'}
       </div>

--- a/src/components/TeleprompterView/features/FileOperations/hooks/useFileImport.ts
+++ b/src/components/TeleprompterView/features/FileOperations/hooks/useFileImport.ts
@@ -12,7 +12,7 @@ export function useFileImport() {
     try {
       const input = document.createElement('input');
       input.type = 'file';
-      input.accept = '.txt,.json';
+      input.accept = '.txt,.json,.csv,.pdf';
       
       const file = await new Promise<File>((resolve) => {
         input.onchange = (e) => {

--- a/src/components/TeleprompterView/features/FileOperations/utils/fileUtils.ts
+++ b/src/components/TeleprompterView/features/FileOperations/utils/fileUtils.ts
@@ -1,4 +1,28 @@
-export const readFileAsText = (file: File): Promise<string> => {
+import type { getDocument as GetDocumentType } from 'pdfjs-dist';
+
+export const readFileAsText = async (file: File): Promise<string> => {
+  if (
+    file.type === 'application/pdf' ||
+    file.name.toLowerCase().endsWith('.pdf')
+  ) {
+    const pdfjs: { getDocument: typeof GetDocumentType; GlobalWorkerOptions: any } =
+      await import('pdfjs-dist/legacy/build/pdf');
+    const workerSrc = new URL(
+      'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
+      import.meta.url
+    ).toString();
+    pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
+    const pdf = await pdfjs.getDocument({ data: await file.arrayBuffer() }).promise;
+    let text = '';
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      const content = await page.getTextContent();
+      text +=
+        content.items.map((item: any) => (item as any).str).join(' ') + '\n';
+    }
+    return text.trim();
+  }
+
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(reader.result as string);

--- a/src/components/TeleprompterView/index.tsx
+++ b/src/components/TeleprompterView/index.tsx
@@ -64,6 +64,8 @@ export default function TeleprompterView() {
           isScrolling={isScrolling}
           speed={settings.speed}
           mirrorText={settings.mirrorText}
+          editable
+          onChange={setContent}
           className="h-[calc(100vh-12rem)] sm:h-[calc(100vh-8rem)]"
         />
       </div>

--- a/src/utils/fileOperations.ts
+++ b/src/utils/fileOperations.ts
@@ -1,3 +1,5 @@
+import type { getDocument as GetDocumentType } from 'pdfjs-dist';
+
 export async function exportText(content: string, filename: string) {
   try {
     const blob = new Blob([content], { type: 'text/plain' });
@@ -18,20 +20,50 @@ export async function importText(): Promise<string> {
   return new Promise((resolve, reject) => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.txt';
-    
+    input.accept = '.txt,.json,.csv,.pdf';
+
     input.onchange = async (e) => {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (!file) return;
-      
+
       try {
-        const text = await file.text();
-        resolve(text);
+        const text = await readFileAsText(file);
+        try {
+          const data = JSON.parse(text);
+          resolve(typeof data.content === 'string' ? data.content : text);
+        } catch {
+          resolve(text);
+        }
       } catch (error) {
         reject(new Error('שגיאה בייבוא הקובץ'));
       }
     };
-    
+
     input.click();
   });
 }
+
+export const readFileAsText = async (file: File): Promise<string> => {
+  if (
+    file.type === 'application/pdf' ||
+    file.name.toLowerCase().endsWith('.pdf')
+  ) {
+    const pdfjs: { getDocument: typeof GetDocumentType; GlobalWorkerOptions: any } =
+      await import('pdfjs-dist/legacy/build/pdf');
+    const workerSrc = new URL(
+      'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
+      import.meta.url
+    ).toString();
+    pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
+    const pdf = await pdfjs.getDocument({ data: await file.arrayBuffer() }).promise;
+    let text = '';
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      const content = await page.getTextContent();
+      text += content.items.map((item: any) => (item as any).str).join(' ') + '\n';
+    }
+    return text.trim();
+  }
+
+  return file.text();
+};


### PR DESCRIPTION
## Summary
- allow importing TXT, JSON, CSV and PDF files
- parse PDF files using `pdfjs-dist`
- support editing the teleprompter text directly
- expose helper to read files in various formats

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68456a6114dc832cb2e0c3ca065f29fe