### PR TITLE
feat: fetch real visitor count

### DIFF
--- a/src/components/TeleprompterEditor/components/VisitorCounter.tsx
+++ b/src/components/TeleprompterEditor/components/VisitorCounter.tsx
@@ -5,10 +5,20 @@ export default function VisitorCounter() {
   const [visitorCount, setVisitorCount] = useState<number>(0);
 
   useEffect(() => {
-    // Simulate visitor count with a random number between 100-1000
-    // In a real app, this would come from an analytics service
-    const randomVisitors = Math.floor(Math.random() * 900) + 100;
-    setVisitorCount(randomVisitors);
+    // Fetch visitor count from a simple analytics service
+    async function fetchCount() {
+      try {
+        const res = await fetch(
+          'https://api.countapi.xyz/hit/teleprompter.example/visits'
+        );
+        const data = await res.json();
+        setVisitorCount(data.value);
+      } catch (error) {
+        console.error('Failed to fetch visitor count', error);
+      }
+    }
+
+    fetchCount();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- replace visitor count simulation with a request to a public counter API

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68456c701df8832cb14a484fa76e3e0d